### PR TITLE
Proposed changed

### DIFF
--- a/stdlogging.py
+++ b/stdlogging.py
@@ -78,5 +78,5 @@ def initStream(logger=None, logger_level=logging.ERROR, stream_getter=None, stre
             sys.stderr = s
 
     stream = stream_getter()
-    sl = StreamToLogger(logger, stream, logger_level)
+    sl = StreamToLogger(logger=logger, stream=stream, logger_level=logger_level)
     stream_setter(sl)


### PR DESCRIPTION
Hi,

I will be glad to receive permission from you to redistribute  my code based on your.

I have come across your repository here https://stackoverflow.com/questions/47325506/making-python-loggers-log-all-stdout-and-stderr-messages. Quote from their:  " But be careful to capture stdout because it's very fragile."
I decided to focus on redirecting stderr only to the logger. If you want you can also redirect stdout, by making 2 calls to `initStream()` package-level method. But, because of https://unix.stackexchange.com/questions/616616/separate-stdout-and-stderr-for-docker-run it is sufficient only to do it for stderr for me (I'm running my application insider Docker container using tty).



Usage example:
`
logging.config.dictConfig(kwargs[conf.GENERAL_KEY][conf.LOG_KEY])
errLogger = logging.getLogger("stderr")
stdlogging.initStream(errLogger)
`

Configuration file (simplified):

`
general:

     log:
       version: 1
       disable_existing_loggers: False
       formatters:
         brief:
           format: "%(message)s"
         detail:
           format: "%(asctime)s %(levelname)s %(threadName)s [%(name)s.%(funcName)s] %(message)s"
           datefmt: "%Y-%m-%d %H:%M:%S"


    handlers:
      console:
        class: logging.StreamHandler
        level: DEBUG
        formatter: detail
        stream: ext://sys.stdout

      all_file_handler:
        class: logging.handlers.TimedRotatingFileHandler
        level: DEBUG
        formatter: detail
        filename: "logs/stream.log"
        when: midnight
        backupCount: 10
        delay: True

      stderr_handler:
        class: logging.handlers.TimedRotatingFileHandler
        level: DEBUG
        formatter: brief
        filename: "logs/stream.log"
        when: midnight
        backupCount: 10
        delay: True

      stderr_console_handler:
        class: logging.StreamHandler
        level: DEBUG
        formatter: brief
        stream: ext://sys.stdout

    loggers:
      hiyapyco:
        level: WARNING
      stderr:
        handlers: [stderr_handler, stderr_console_handler]
        propagate: False



    root:
      level: DEBUG
      handlers: [all_file_handler,console]

`

The essential part is

`
      stderr:
        handlers: [stderr_handler, stderr_console_handler]
        propagate: False
`
